### PR TITLE
Switch from IpAddress to IPAddress as defined in the new schema

### DIFF
--- a/AnalyticsRules/AzureHoundActivityDetected.yaml
+++ b/AnalyticsRules/AzureHoundActivityDetected.yaml
@@ -7,7 +7,7 @@ severity: Medium
 query: |-
   MicrosoftGraphActivityLogs
   | where UserAgent has "azurehound"
-  | summarize QueriesSent=count() by UserId, IpAddress, ServicePrincipalId, AppId, TokenIssuedAt, Location, SignInActivityId, SourceSystem, AadTenantId, UserAgent
+  | summarize QueriesSent=count() by UserId, IPAddress, ServicePrincipalId, AppId, TokenIssuedAt, Location, SignInActivityId, SourceSystem, AadTenantId, UserAgent
   | extend ConfidenceScore = 1
   | extend RemediationSteps = "Identify the identity and device used for this activity and confirm this is not a security test. If you can rule out a security test initiate the  incident response process to decide if the attacker can be evicted or should be observed"
 suppressionDuration: 5h
@@ -28,7 +28,7 @@ entityMappings:
 - entityType: IP
   fieldMappings:
   - identifier: Address
-    columnName: IpAddress
+    columnName: IPAddress
 incidentConfiguration:
   createIncident: true
   groupingConfiguration:

--- a/AnalyticsRules/AzureHoundReconnaissanceDetected.yaml
+++ b/AnalyticsRules/AzureHoundReconnaissanceDetected.yaml
@@ -49,7 +49,7 @@ query: |-
       | extend NormalizedRequestUri = replace_regex(NormalizedRequestUri, @'\?.*$', @'')
       | summarize
           GraphEndpointsCalled = make_set(NormalizedRequestUri, 1000),
-          IPAddresses = make_set(IpAddress)
+          IPAddresses = make_set(IPAddress)
           by ObjectId, ObjectType
       | project
           ObjectId,

--- a/AnalyticsRules/PurpleKnightReconnaissanceDetected.yaml
+++ b/AnalyticsRules/PurpleKnightReconnaissanceDetected.yaml
@@ -58,7 +58,7 @@ query: |-
       | extend NormalizedRequestUri = replace_regex(NormalizedRequestUri, @'\?.*$', @'')
       | summarize
           GraphEndpointsCalled = make_set(NormalizedRequestUri, 1000),
-          IPAddresses = make_set(IpAddress)
+          IPAddresses = make_set(IPAddress)
           by ObjectId, ObjectType
       | project
           ObjectId,


### PR DESCRIPTION
The column `IpAddress` was replaced by `IPAddress` in the final version and the change is currently rolling out.

Fixing #1 