### PR TITLE
Extend queryPeriod & avoid redundancies

### DIFF
--- a/AnalyticsRules/AnonymousRetrievalOfAzureBlobVersions.yaml
+++ b/AnalyticsRules/AnonymousRetrievalOfAzureBlobVersions.yaml
@@ -8,7 +8,7 @@ description: |-
   While public access to storage containers may be intentional, attackers frequently target these containers to look for "soft-deleted" data or previous versions of files. They do this to uncover sensitive information (such as hardcoded credentials, API keys, or PII) that may have been present in an older version of a file but removed in the current "live" version.
 severity: Low
 queryFrequency: 10m
-queryPeriod: 12m
+queryPeriod: 22m
 triggerOperator: gt
 triggerThreshold: 0
 tactics:
@@ -33,6 +33,7 @@ query: |-
   | join kind=inner (VersionEnumeration) on ObjectKey, IPAddress
   | extend TimeDifference = datetime_diff('minute', TimeGenerated, EnumerationTimeGenerated)
   | where TimeDifference between (0 .. 10)
+  | where TimeGenerated >= ago(10m) or EnumerationTimeGenerated >= ago(10m)
 suppressionEnabled: false
 incidentConfiguration:
   createIncident: true


### PR DESCRIPTION
Hi @f-bader, I believe I've found a potential blindspot in the detection, due to a too short queryPeriod based on the time span set in your query. Let ,me explain this via a fictional example: The enumeration event happens at 11:55 and the GetBlob event at 12:03, so the detection should hit on those events in theory. If the detection runs at 12:00, nothing happens since only one event (enumeration) occured thus far. If it then runs at 12:10 again, due to its 10m queryFrequency, it picks up the second event (GetBlob at 12:03), however it will not hit since the enumeration has slipped out of the lookback (happened 15m ago, but our queryPeriod is only 12m). So to solve this, what do you think about this proposed change to queryPeriod? The change to the query with new line 36 would eliminate potential redundant alerting as a result of the increased queryPeriod.